### PR TITLE
Add full-screen overlay with zoom controls for diagrams

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,18 @@
         <div class="preview">
           <div class="preview-header">
             <div class="panel-title">Diagram preview</div>
-            <div class="download-menu" id="downloadMenu" hidden>
+            <div class="preview-actions">
+              <button
+                id="openOverlay"
+                class="preview-action"
+                type="button"
+                title="Expand diagram"
+                hidden
+              >
+                <span aria-hidden="true">⤢</span>
+                <span class="sr-only">Expand diagram</span>
+              </button>
+              <div class="download-menu" id="downloadMenu" hidden>
               <button
                 class="download-trigger"
                 id="downloadTrigger"
@@ -55,10 +66,11 @@
                   />
                 </svg>
               </button>
-              <div class="download-dropdown" id="downloadList" role="menu" hidden>
-                <a data-format="png" role="menuitem" target="_blank" rel="noopener">Download PNG</a>
-                <a data-format="svg" role="menuitem" target="_blank" rel="noopener">Download SVG</a>
-                <a data-format="txt" role="menuitem" target="_blank" rel="noopener">Download TXT</a>
+                <div class="download-dropdown" id="downloadList" role="menu" hidden>
+                  <a data-format="png" role="menuitem" target="_blank" rel="noopener">Download PNG</a>
+                  <a data-format="svg" role="menuitem" target="_blank" rel="noopener">Download SVG</a>
+                  <a data-format="txt" role="menuitem" target="_blank" rel="noopener">Download TXT</a>
+                </div>
               </div>
             </div>
           </div>
@@ -69,6 +81,34 @@
       </div>
     </section>
   </main>
+
+  <div id="diagramOverlay" class="diagram-overlay" hidden>
+    <div class="overlay-frame" role="dialog" aria-modal="true" aria-label="Expanded PlantUML diagram">
+      <div class="overlay-toolbar">
+        <div class="overlay-zoom-controls" role="group" aria-label="Zoom controls">
+          <button id="zoomOut" class="overlay-button" type="button" title="Zoom out">
+            <span aria-hidden="true">−</span>
+            <span class="sr-only">Zoom out</span>
+          </button>
+          <button id="zoomReset" class="overlay-button" type="button" title="Reset zoom">
+            <span aria-hidden="true">⟳</span>
+            <span class="sr-only">Reset zoom</span>
+          </button>
+          <button id="zoomIn" class="overlay-button" type="button" title="Zoom in">
+            <span aria-hidden="true">＋</span>
+            <span class="sr-only">Zoom in</span>
+          </button>
+        </div>
+        <button id="closeOverlay" class="overlay-button close-button" type="button" title="Close overlay">
+          <span aria-hidden="true">✕</span>
+          <span class="sr-only">Close overlay</span>
+        </button>
+      </div>
+      <div class="overlay-stage">
+        <img id="overlayImage" class="overlay-image" alt="Expanded UML diagram" />
+      </div>
+    </div>
+  </div>
 
   <script src="https://unpkg.com/plantuml-encoder/dist/plantuml-encoder.min.js"></script>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -10,6 +10,21 @@ const downloadTrigger = document.getElementById('downloadTrigger');
 const downloadList = document.getElementById('downloadList');
 const downloadLinks = downloadList ? downloadList.querySelectorAll('a[data-format]') : [];
 const baseUrl = 'https://www.plantuml.com/plantuml';
+const openOverlayButton = document.getElementById('openOverlay');
+const overlay = document.getElementById('diagramOverlay');
+const overlayImage = document.getElementById('overlayImage');
+const overlayCloseButton = document.getElementById('closeOverlay');
+const zoomInButton = document.getElementById('zoomIn');
+const zoomOutButton = document.getElementById('zoomOut');
+const zoomResetButton = document.getElementById('zoomReset');
+
+const ZOOM_STEP = 0.25;
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 3;
+
+let currentDiagramSrc = '';
+let currentDiagramAlt = 'Rendered UML diagram';
+let overlayZoom = 1;
 
 function initCanvas() {
   width = canvas.width = window.innerWidth;
@@ -67,6 +82,42 @@ function updateDownloadLinks(encoded) {
   });
 }
 
+function applyOverlayZoom(scale) {
+  if (!overlayImage) return;
+  overlayZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Number(scale)));
+  overlayImage.style.transform = `scale(${overlayZoom})`;
+}
+
+function showOverlay() {
+  if (!overlay || !overlayImage || !currentDiagramSrc) return;
+  overlayImage.src = currentDiagramSrc;
+  overlayImage.alt = currentDiagramAlt;
+  overlay.hidden = false;
+  requestAnimationFrame(() => {
+    overlay.classList.add('is-visible');
+    applyOverlayZoom(1);
+  });
+}
+
+function hideOverlay(immediate = false) {
+  if (!overlay || overlay.hidden) return;
+
+  const finalizeClose = () => {
+    overlay.hidden = true;
+    overlayImage.src = '';
+    overlay.removeEventListener('transitionend', finalizeClose);
+  };
+
+  if (immediate) {
+    overlay.classList.remove('is-visible');
+    finalizeClose();
+    return;
+  }
+
+  overlay.classList.remove('is-visible');
+  overlay.addEventListener('transitionend', finalizeClose);
+}
+
 function renderDiagram() {
   const input = umlInput ? umlInput.value.trim() : '';
   console.log("📝 Code being rendered:", input);
@@ -77,6 +128,11 @@ function renderDiagram() {
     if (downloadMenu) {
       downloadMenu.hidden = true;
     }
+    if (openOverlayButton) {
+      openOverlayButton.hidden = true;
+    }
+    currentDiagramSrc = '';
+    hideOverlay(true);
     closeDownloadDropdown();
     return;
   }
@@ -95,12 +151,22 @@ function renderDiagram() {
     }
     updateDownloadLinks(encoded);
     closeDownloadDropdown();
+    currentDiagramSrc = img.src;
+    currentDiagramAlt = img.alt;
+    if (openOverlayButton) {
+      openOverlayButton.hidden = false;
+    }
     console.log("✅ Diagram rendered successfully.");
   } catch (error) {
     output.innerHTML = `<p class="preview-placeholder">Something went wrong while rendering the diagram.</p>`;
     if (downloadMenu) {
       downloadMenu.hidden = true;
     }
+    if (openOverlayButton) {
+      openOverlayButton.hidden = true;
+    }
+    currentDiagramSrc = '';
+    hideOverlay(true);
     closeDownloadDropdown();
     console.error("❌ Error rendering diagram:", error);
   }
@@ -123,6 +189,7 @@ if (downloadTrigger && downloadList && downloadMenu) {
   document.addEventListener('keydown', event => {
     if (event.key === 'Escape') {
       closeDownloadDropdown();
+      hideOverlay();
     }
   });
 }
@@ -130,6 +197,48 @@ if (downloadTrigger && downloadList && downloadMenu) {
 if (umlInput) {
   umlInput.addEventListener('input', () => {
     renderDiagram();
+  });
+}
+
+if (openOverlayButton) {
+  openOverlayButton.addEventListener('click', showOverlay);
+}
+
+if (zoomInButton) {
+  zoomInButton.addEventListener('click', () => {
+    applyOverlayZoom(overlayZoom + ZOOM_STEP);
+  });
+}
+
+if (zoomOutButton) {
+  zoomOutButton.addEventListener('click', () => {
+    applyOverlayZoom(overlayZoom - ZOOM_STEP);
+  });
+}
+
+if (zoomResetButton) {
+  zoomResetButton.addEventListener('click', () => {
+    applyOverlayZoom(1);
+  });
+}
+
+if (overlayCloseButton) {
+  overlayCloseButton.addEventListener('click', () => hideOverlay());
+}
+
+if (overlay) {
+  overlay.addEventListener('click', event => {
+    if (event.target === overlay) {
+      hideOverlay();
+    }
+  });
+}
+
+if (output) {
+  output.addEventListener('click', event => {
+    if (event.target && event.target.classList.contains('diagram-img')) {
+      showOverlay();
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -80,6 +80,39 @@ body {
   gap: 1rem;
 }
 
+.preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.preview-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.85);
+  color: #cbd5f5;
+  cursor: pointer;
+  font-size: 1.1rem;
+  transition: border-color 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.preview-action:hover,
+.preview-action:focus-visible {
+  border-color: #93c5fd;
+  color: #e0f2fe;
+  transform: translateY(-1px);
+}
+
+.preview-action:focus-visible {
+  outline: 2px solid rgba(147, 197, 253, 0.45);
+  outline-offset: 2px;
+}
+
 .download-menu {
   position: relative;
   display: flex;
@@ -199,6 +232,129 @@ body {
   font-size: 0.95rem;
   color: #94a3c6;
   text-align: center;
+}
+
+.diagram-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 6vw, 3rem);
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(24px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 40;
+}
+
+.diagram-overlay.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.overlay-frame {
+  width: min(90vw, 1200px);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border-radius: 1.25rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 32px 80px rgba(15, 23, 42, 0.55);
+  transform: scale(0.96);
+  transition: transform 0.3s ease;
+}
+
+.diagram-overlay.is-visible .overlay-frame {
+  transform: scale(1);
+}
+
+.overlay-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.overlay-zoom-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.overlay-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: #e0e7ff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.overlay-button:hover,
+.overlay-button:focus-visible {
+  border-color: #93c5fd;
+  background: rgba(59, 130, 246, 0.18);
+  transform: translateY(-1px);
+}
+
+.overlay-button:focus-visible {
+  outline: 2px solid rgba(147, 197, 253, 0.45);
+  outline-offset: 2px;
+}
+
+.close-button {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.overlay-stage {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+}
+
+.overlay-image {
+  max-width: none;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  transition: transform 0.3s ease;
+  transform-origin: center;
+}
+
+.diagram-overlay:not(.is-visible) .overlay-image {
+  transform: scale(0.95);
+}
+
+@media (max-width: 640px) {
+  .overlay-frame {
+    width: min(95vw, 640px);
+    gap: 1rem;
+  }
+
+  .overlay-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .overlay-zoom-controls {
+    justify-content: center;
+  }
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- add an overlay expand button to open a frosted-glass full-screen view of the rendered diagram
- implement zoom in/out/reset controls, smooth scaling, and background click/escape close behavior
- refresh styling to support the new preview actions and overlay presentation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d6a142c5a4832b886fab6847c0a4a6