### PR TITLE
Consolidate intro heading into info card

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,11 +62,15 @@
   <main id="content">
     <section class="layout">
       <header class="intro">
-        <h1 class="title">🌿 PlantUML Viewer</h1>
-        <p class="description">
-          Paste your PlantUML markup into the editor and the diagram will render automatically.
-          You can also share a diagram by appending it to the URL with <code>?code=</code>.
-        </p>
+        <div class="info-card" role="note">
+          <h1 class="title info-card-title">
+            🌿 PlantUML Viewer<br />
+            <span class="info-card-subtitle">
+              Paste your PlantUML markup into the editor and the diagram will render automatically.
+              You can also share a diagram by appending it to the URL with ?code=.
+            </span>
+          </h1>
+        </div>
       </header>
 
       <div class="diagram-container">

--- a/style.css
+++ b/style.css
@@ -91,16 +91,35 @@ body.theme-matrix-light {
   text-align: center;
 }
 
+.info-card {
+  margin: clamp(1rem, 3vw, 1.5rem) auto 0;
+  width: 80vw;
+  max-width: 100%;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  background: var(--panel-soft-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(14px);
+}
+
 .title {
   font-size: clamp(2rem, 4vw, 3rem);
   font-weight: 700;
-  margin: 0 0 0.75rem;
+  margin: 0;
+  color: var(--text-primary);
 }
 
-.description {
-  margin: 0;
-  font-size: clamp(1rem, 2.2vw, 1.25rem);
-  line-height: 1.6;
+.info-card-title {
+  line-height: 1.2;
+}
+
+.info-card-subtitle {
+  display: block;
+  margin-top: clamp(0.75rem, 2vw, 1rem);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  font-weight: 400;
+  line-height: 1.7;
   color: var(--text-muted);
 }
 


### PR DESCRIPTION
## Summary
- move the main PlantUML Viewer heading into the intro info card to remove the duplicated title
- render the usage guidance as a subtitle beneath the heading while keeping the 80% width card layout
- update the card styling to support the new heading/subtitle structure

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68d7061c94f0832b8c054aa4fe2c1bc6