### PR TITLE
Add matrix animation controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,39 @@
     </div>
   </nav>
 
+  <section class="matrix-controls" aria-label="Matrix animation controls">
+    <div class="matrix-control">
+      <label class="matrix-control-label" for="fontSizeControl">Glyph size</label>
+      <div class="matrix-control-input">
+        <input
+          id="fontSizeControl"
+          class="matrix-slider"
+          type="range"
+          min="10"
+          max="28"
+          step="1"
+          value="14"
+        />
+        <span id="fontSizeValue" class="matrix-control-value" aria-live="polite">14px</span>
+      </div>
+    </div>
+    <div class="matrix-control">
+      <label class="matrix-control-label" for="speedControl">Glyph speed</label>
+      <div class="matrix-control-input">
+        <input
+          id="speedControl"
+          class="matrix-slider"
+          type="range"
+          min="0.5"
+          max="2"
+          step="0.05"
+          value="1"
+        />
+        <span id="speedValue" class="matrix-control-value" aria-live="polite">1×</span>
+      </div>
+    </div>
+  </section>
+
   <main id="content">
     <section class="layout">
       <header class="intro">

--- a/style.css
+++ b/style.css
@@ -47,6 +47,96 @@ body {
   background: transparent;
 }
 
+#themeMenuToggle {
+  margin: 0;
+}
+
+.matrix-controls {
+  position: sticky;
+  top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1rem clamp(1rem, 4vw, 2rem);
+  margin: 0 auto clamp(1.5rem, 3vw, 2rem);
+  width: min(100%, 60rem);
+  z-index: 5;
+  background: var(--panel-soft-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(12px);
+}
+
+.matrix-control {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.matrix-control-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.matrix-control-input {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.matrix-slider {
+  appearance: none;
+  width: clamp(8rem, 12vw, 10rem);
+  height: 0.35rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.4);
+  outline: none;
+  cursor: pointer;
+  position: relative;
+}
+
+.matrix-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.25);
+  transition: transform 0.2s ease;
+}
+
+.matrix-slider::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.25);
+  transition: transform 0.2s ease;
+}
+
+.matrix-slider:focus-visible {
+  outline: 2px solid var(--accent-soft-outline);
+  outline-offset: 4px;
+}
+
+.matrix-slider::-webkit-slider-thumb:active,
+.matrix-slider::-moz-range-thumb:active {
+  transform: scale(1.08);
+}
+
+.matrix-control-value {
+  min-width: 2.75rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
 body.theme-matrix-light {
   color-scheme: light;
   --body-bg: #f8fafc;


### PR DESCRIPTION
## Summary
- add a sticky control panel with sliders for matrix glyph size and speed
- style the new controls to match existing matrix themes
- update the animation engine to respect runtime font size and speed adjustments

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d709c3975c832b8c40005bc3122ac8