### PR TITLE
Add line numbers to PlantUML editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,11 +109,18 @@
       <div class="diagram-container">
         <div class="editor">
           <label for="umlInput" class="panel-title">PlantUML source</label>
-          <textarea
-            id="umlInput"
-            class="editor-input"
-            placeholder="@startuml\nAlice -> Bob : Hello\n@enduml"
-          ></textarea>
+          <div class="editor-wrapper">
+            <div
+              id="umlLineNumbers"
+              class="editor-line-numbers"
+              aria-hidden="true"
+            ></div>
+            <textarea
+              id="umlInput"
+              class="editor-input"
+              placeholder="@startuml\nAlice -> Bob : Hello\n@enduml"
+            ></textarea>
+          </div>
         </div>
         <div class="preview">
           <div class="preview-header">

--- a/script.js
+++ b/script.js
@@ -43,6 +43,7 @@ let currentThemeKey = 'matrix-classic';
 let currentTheme = THEMES[currentThemeKey];
 let activeBodyThemeClass = null;
 const umlInput = document.getElementById('umlInput');
+const lineNumbers = document.getElementById('umlLineNumbers');
 const output = document.getElementById('output');
 const downloadMenu = document.getElementById('downloadMenu');
 const downloadTrigger = document.getElementById('downloadTrigger');
@@ -102,6 +103,17 @@ function updateSpeedLabel() {
 
 updateFontSizeLabel();
 updateSpeedLabel();
+
+function updateLineNumbers() {
+  if (!umlInput || !lineNumbers) return;
+  const value = umlInput.value;
+  const lineCount = Math.max(1, value.split('\n').length);
+  const markup = Array.from({ length: lineCount }, (_, index) => `<span>${index + 1}</span>`).join('');
+  lineNumbers.innerHTML = markup;
+  lineNumbers.scrollTop = umlInput.scrollTop;
+}
+
+updateLineNumbers();
 
 function getRandomSpeed() {
   const baseRange =
@@ -440,7 +452,14 @@ if (downloadTrigger && downloadList && downloadMenu) {
 
 if (umlInput) {
   umlInput.addEventListener('input', () => {
+    updateLineNumbers();
     renderDiagram();
+  });
+
+  umlInput.addEventListener('scroll', () => {
+    if (lineNumbers) {
+      lineNumbers.scrollTop = umlInput.scrollTop;
+    }
   });
 }
 
@@ -489,12 +508,12 @@ if (output) {
 window.addEventListener('DOMContentLoaded', () => {
   const code = getCodeFromURL();
   console.log("🧠 Decoded code from URL:", code);
-  if (code) {
-    const textarea = document.getElementById('umlInput');
-    textarea.value = code;
+  if (code && umlInput) {
+    umlInput.value = code;
     console.log("✅ Textarea populated.");
     renderDiagram();
   } else {
     console.warn("⚠️ No 'code' parameter found.");
   }
+  updateLineNumbers();
 });

--- a/style.css
+++ b/style.css
@@ -347,24 +347,65 @@ body.theme-matrix-light {
   color: var(--text-muted);
 }
 
+.editor-wrapper {
+  position: relative;
+  display: flex;
+  border-radius: 0.75rem;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-soft-bg);
+  overflow: hidden;
+}
+
+.editor-wrapper:focus-within {
+  border-color: var(--button-hover-border);
+  box-shadow: 0 0 0 2px var(--accent-soft-outline);
+}
+
+.editor-wrapper:focus-within .editor-line-numbers {
+  color: var(--text-primary);
+}
+
+.editor-line-numbers {
+  padding: 0.75rem 0.75rem 0.75rem 1rem;
+  text-align: right;
+  min-width: 3ch;
+  font-size: 1rem;
+  line-height: 1.5;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  border-right: 1px solid var(--panel-border);
+  user-select: none;
+  white-space: pre;
+  background: linear-gradient(
+    to bottom,
+    rgba(148, 163, 184, 0.12),
+    rgba(148, 163, 184, 0.04)
+  );
+}
+
+.editor-line-numbers span {
+  display: block;
+}
+
 .editor-input {
   width: 100%;
   min-height: clamp(12rem, 35vw, 18rem);
   resize: vertical;
-  border-radius: 0.75rem;
-  border: 1px solid var(--panel-border);
+  border-radius: 0;
+  border: none;
   padding: 0.75rem 1rem;
   font-size: 1rem;
   line-height: 1.5;
-  background: var(--panel-soft-bg);
+  background: transparent;
   color: var(--text-primary);
+  font-family: 'IBM Plex Mono', 'Fira Code', monospace;
+  flex: 1;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .editor-input:focus {
   outline: none;
-  border-color: var(--button-hover-border);
-  box-shadow: 0 0 0 2px var(--accent-soft-outline);
+  box-shadow: none;
 }
 
 .preview-output {


### PR DESCRIPTION
## Summary
- add a line number gutter to the PlantUML source editor for easier reference
- style the editor container so the line numbers integrate with existing themes
- update the script to keep the line numbers in sync on load, input, and scrolling

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ee0dfb1288832b9d83f14cf63a14c6